### PR TITLE
Netlify: Add config for Hugo

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -57,3 +57,26 @@
 	from = "/*"
 	to = "/cs/404/"
 	status = 404
+
+[build]
+  publish = "public"
+  command = "hugo --gc --minify"
+
+[context.production.environment]
+  HUGO_ENV = "production"
+  HUGO_ENABLEGITINFO = "true"
+
+[context.split1]
+  command = "hugo --gc --minify --enableGitInfo"
+
+  [context.split1.environment]
+	HUGO_ENV = "production"
+
+[context.deploy-preview]
+  command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+
+[context.branch-deploy]
+  command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+
+[context.next.environment]
+  HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
There was problem with redirecting on Netlify Deploy previews.

**Before:**
You clicked the preview link and get redirected to production site (domain).

**After:**
You clicked the preview link and get redirected to preview site (domain).