### PR TITLE
fix: images width in blog list

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -198,6 +198,10 @@ main.notfound a {
 
 .c-bloglist__item {
     margin-bottom: 2rem;
+
+    img {
+        width: 100%;
+    }
 }
 
 .c-bloglist__metas {


### PR DESCRIPTION
prevent images from overflowing their containers in blog list